### PR TITLE
Export a `LanguageDescription` for the mindmap language

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
-import { LRLanguage, LanguageSupport } from '@codemirror/language';
+import { LRLanguage, LanguageDescription, LanguageSupport } from '@codemirror/language';
 import { parser as mindmapParser } from './mindmap/mindmap.grammar';
 export { mindmapTags } from './mindmap/tags';
 
 export const mindmapLanguage = LRLanguage.define({
   name: 'mindmap',
   parser: mindmapParser,
+});
+
+export const mindmapLanguageDescription = LanguageDescription.of({
+  name: 'mermaid',
+  load: async () => {
+    return mindmap();
+  },
 });
 
 export function mindmap() {


### PR DESCRIPTION
In order to use this as a supported language in Markdown, we need a `LanguageDescription`. Ideally, it would use a dynamic import for the language, but that would require you to refactor your language definition into a separate module.