### PR TITLE
Define parent tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemirror-lang-mermaid",
   "author": "Nathan Vaughn <inspirnathan@gmail.com>",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mermaid language support for CodeMirror",
   "scripts": {
     "test": "mocha test/test.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemirror-lang-mermaid",
   "author": "Nathan Vaughn <inspirnathan@gmail.com>",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": "Mermaid language support for CodeMirror",
   "scripts": {
     "test": "mocha test/test.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,4 @@ export {
 
 export { mermaid, mindmap, pie } from './language-support';
 
-export { mindmapTags, pieTags } from './tags';
+export { mermaidTags, mindmapTags, pieTags } from './tags';

--- a/src/tags/index.ts
+++ b/src/tags/index.ts
@@ -1,7 +1,11 @@
-import { Tag } from '@lezer/highlight';
+import { Tag, tags as t } from '@lezer/highlight';
+
+export const mermaidTags = {
+  diagramName: Tag.define(t.typeName)
+}
 
 export const mindmapTags = {
-  diagramName: Tag.define(),
+  diagramName: Tag.define(mermaidTags.diagramName),
   lineText1: Tag.define(),
   lineText2: Tag.define(),
   lineText3: Tag.define(),
@@ -10,11 +14,11 @@ export const mindmapTags = {
 };
 
 export const pieTags = {
-  diagramName: Tag.define(),
-  lineComment: Tag.define(),
-  number: Tag.define(),
-  showData: Tag.define(),
-  string: Tag.define(),
-  title: Tag.define(),
-  titleText: Tag.define(),
+  diagramName: Tag.define(mermaidTags.diagramName),
+  lineComment: Tag.define(t.lineComment),
+  number: Tag.define(t.number),
+  showData: Tag.define(t.keyword),
+  string: Tag.define(t.string),
+  title: Tag.define(t.keyword),
+  titleText: Tag.define(t.string),
 };


### PR DESCRIPTION
When you define a parent tag for more specialized, it allows you to target the parent tag for highlighting in addition to more specialized.

For instance, I may already have highlighting defined for keywords, strings, and numbers, and with this change, those tokes will be automatically highlighted without doing anything.